### PR TITLE
Added more SDK methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ debug = true
 lto = true
 
 [workspace.dependencies]
-vex-sdk = "0.23.0"
+vex-sdk = "0.26.0"
 
 [workspace.dependencies.vexide]
-version = "0.6.1"
+version = "0.7.0"
 default-features = false
-features = ["core", "devices", "panic", "display_panics"]
+features = ["allocator", "core", "devices", "panic", "display_panics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ vex-sdk = "0.26.0"
 [workspace.dependencies.vexide]
 version = "0.7.0"
 default-features = false
-features = ["allocator", "core", "devices", "panic", "display_panics"]
+features = ["allocator", "devices", "panic", "display_panics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ lto = true
 vex-sdk = "0.23.0"
 
 [workspace.dependencies.vexide]
-version = "0.5.1"
+version = "0.6.1"
 default-features = false
 features = ["core", "devices", "panic", "display_panics"]

--- a/armv7a-vex-v5.json
+++ b/armv7a-vex-v5.json
@@ -7,6 +7,7 @@
     "env": "v5",
     "panic-strategy": "abort",
     "relocation-model": "static",
+    "llvm-floatabi": "hard",
     "llvm-target": "armv7a-none-eabihf",
     "features": "+v7,+neon,+vfp3d16,+thumb2",
     "linker": "rust-lld",

--- a/packages/runtime/src/bin/hydrozoa.rs
+++ b/packages/runtime/src/bin/hydrozoa.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Context;
 use runtime::{platform, sdk, teavm, Data};
-use vexide::{core::program::exit, prelude::*};
+use vexide::{program::exit, prelude::*};
 use vexide_wasm_startup::{startup, CodeSignature, ProgramFlags, ProgramOwner, ProgramType};
 use wasm3::{Environment, Store};
 

--- a/packages/runtime/src/libc_support.rs
+++ b/packages/runtime/src/libc_support.rs
@@ -6,7 +6,7 @@ use core::{
 };
 
 use hashbrown::HashMap;
-use vexide::core::{print, sync::Mutex};
+use vexide::{io::print, sync::Mutex};
 
 // these really get more unhinged the more you read
 

--- a/packages/runtime/src/sdk.rs
+++ b/packages/runtime/src/sdk.rs
@@ -3,7 +3,7 @@
 use core::ffi::c_double;
 
 use vex_sdk::*;
-use vexide::{core::println, prelude::Display};
+use vexide::prelude::Display;
 use wasm3::{error::Trap, store::AsContextMut, Instance, Store};
 
 use crate::{platform::draw_error, teavm::get_cstring, Data};
@@ -89,11 +89,11 @@ pub fn link(store: &mut Store<Data>, instance: &mut Instance<Data>) -> anyhow::R
         &mut *store,
         "hydrozoa",
         "getByteArrayPointer",
-        |mut ctx, (address, size): (i32, i32)| {
+        |mut ctx, address: i32| {
             let teavm = ctx.data().teavm.clone().unwrap();
             let array_ptr = (teavm.byte_array_data)(ctx.as_context_mut(), address).unwrap();
             let memory = ctx.memory_mut();
-            Ok(memory.as_mut_ptr().wrapping_offset(array_ptr) as i32)
+            Ok(memory.as_mut_ptr().wrapping_offset(array_ptr as isize) as i32)
         },
     )?;
 

--- a/packages/runtime/src/sdk.rs
+++ b/packages/runtime/src/sdk.rs
@@ -1,16 +1,14 @@
 #![allow(non_snake_case)]
 
-use alloc::{borrow::ToOwned, string::ToString};
 use core::ffi::c_double;
 
-use vex_sdk::{
-    V5MotorBrakeMode, V5MotorControlMode, V5MotorEncoderUnits, V5MotorGearset, V5_ControllerId,
-    V5_ControllerIndex, V5_DeviceType,
-};
+use vex_sdk::*;
 use vexide::{core::println, prelude::Display};
 use wasm3::{error::Trap, store::AsContextMut, Instance, Store};
 
 use crate::{platform::draw_error, teavm::get_cstring, Data};
+
+extern crate alloc;
 
 macro_rules! link {
     ($instance:ident, $store:ident, mod $module:literal {
@@ -76,6 +74,7 @@ pub fn link(store: &mut Store<Data>, instance: &mut Instance<Data>) -> anyhow::R
         |mut ctx, string: i32| -> Result<(), Trap> {
             let string = get_cstring(&mut ctx, string);
             let msg = string.to_string_lossy();
+            println!("{}", msg);
 
             let mut display = unsafe { Display::new() };
 
@@ -89,7 +88,63 @@ pub fn link(store: &mut Store<Data>, instance: &mut Instance<Data>) -> anyhow::R
         },
     )?;
 
+    instance.link_closure(
+        &mut *store,
+        "hydrozoa",
+        "getByteArrayPointer",
+        |mut ctx, (address, size): (i32, i32)| {
+            let teavm = ctx.data().teavm.clone().unwrap();
+            let array_ptr = (teavm.byte_array_data)(ctx.as_context_mut(), address).unwrap();
+            let memory = ctx.memory_mut();
+            let slice = &mut memory[array_ptr as usize..(array_ptr as usize + size as usize)];
+
+            let magic = unsafe {
+                // SAFETY: V5_DeviceType is a repr(transparent) struct holding a u8
+                core::mem::transmute::<*mut u8, *mut V5_DeviceType>(slice.as_mut_ptr())
+            };
+            Ok(magic as i32)
+        },
+    )?;
+
+    // instance.link_closure(&mut *store, "hydrozoa", "alloc", |_ctx, size: i32| {
+    //     let layout = Layout::from_size_align(size as usize, 1).unwrap();
+    //     let address: i32;
+    //     unsafe {
+    //         address = alloc::alloc::alloc(layout) as i32;
+    //     }
+    //     Ok(address)
+    // })?;
+
+    // instance.link_closure(
+    //     &mut *store,
+    //     "hydrozoa",
+    //     "readByte",
+    //     |_ctx, (address, offset): (i32, i32)| {
+    //         let pointer: *const u8;
+    //         let byte: u8;
+    //         unsafe {
+    //             pointer = &*(address as *const u8);
+    //             let offsetPointer = pointer.byte_offset(offset as isize);
+    //             byte = *offsetPointer;
+    //         }
+    //         Ok(byte as i32)
+    //     },
+    // )?;
+
     link!(instance, store, mod "vex" {
+        // System
+        fn vexSystemTimeGet() -> u32;
+        fn vexSystemExitRequest();
+        fn vexSystemHighResTimeGet() -> u64;
+        fn vexSystemPowerupTimeGet() -> u64;
+        fn vexSystemLinkAddrGet() -> u32;
+        fn vexSystemVersion() -> u32;
+        fn vexStdlibVersion() -> u32;
+
+        // Misc
+        fn vexTasksRun();
+        fn vexCompetitionStatus() -> u32;
+
         // Display
         fn vexDisplayForegroundColor(col: u32);
         fn vexDisplayBackgroundColor(col: u32);
@@ -116,80 +171,6 @@ pub fn link(store: &mut Store<Data>, instance: &mut Instance<Data>) -> anyhow::R
         fn vexDisplayClipRegionSetWithIndex(index: i32, x1: i32, y1: i32, x2: i32, y2: i32);
         // fn vexImageBmpRead(ibuf: *const u8, oBuf: *mut v5_image, maxw: u32, maxh: u32) -> u32;
         // fn vexImagePngRead(ibuf: *const u8, oBuf: *mut v5_image, maxw: u32, maxh: u32, ibuflen: u32) -> u32;
-
-        // Controller
-        fn vexControllerGet(id: u32 as V5_ControllerId, index: u32 as V5_ControllerIndex) -> i32;
-        fn vexControllerConnectionStatusGet(id: u32 as V5_ControllerId) -> u32, in .0;
-
-        // Device
-        fn vexDeviceGetByIndex(index: u32) -> u32;
-
-
-        // Motor
-        fn vexDeviceMotorVelocitySet(device: u32, velocity: i32);
-        fn vexDeviceMotorVelocityGet(device: u32) -> i32;
-        fn vexDeviceMotorActualVelocityGet(device: u32) -> c_double;
-        fn vexDeviceMotorDirectionGet(device: u32) -> i32;
-        fn vexDeviceMotorModeSet(device: u32, mode: u32 as V5MotorControlMode);
-        fn vexDeviceMotorModeGet(device: u32) -> u32, in .0;
-        fn vexDeviceMotorPwmSet(device: u32, pwm: i32);
-        fn vexDeviceMotorPwmGet(device: u32) -> i32;
-        fn vexDeviceMotorCurrentLimitSet(device: u32, limit: i32);
-        fn vexDeviceMotorCurrentLimitGet(device: u32) -> i32;
-        fn vexDeviceMotorCurrentGet(device: u32) -> i32;
-        fn vexDeviceMotorPowerGet(device: u32) -> c_double;
-        fn vexDeviceMotorTorqueGet(device: u32) -> c_double;
-        fn vexDeviceMotorEfficiencyGet(device: u32) -> c_double;
-        fn vexDeviceMotorTemperatureGet(device: u32) -> c_double;
-        fn vexDeviceMotorOverTempFlagGet(device: u32) -> bool;
-        fn vexDeviceMotorCurrentLimitFlagGet(device: u32) -> bool;
-        fn vexDeviceMotorZeroVelocityFlagGet(device: u32) -> bool;
-        fn vexDeviceMotorZeroPositionFlagGet(device: u32) -> bool;
-        fn vexDeviceMotorReverseFlagSet(device: u32, reverse: bool);
-        fn vexDeviceMotorReverseFlagGet(device: u32) -> bool;
-        fn vexDeviceMotorEncoderUnitsSet(device: u32, units: u32 as V5MotorEncoderUnits);
-        fn vexDeviceMotorEncoderUnitsGet(device: u32) -> u32, in .0;
-        fn vexDeviceMotorBrakeModeSet(device: u32, mode: u32 as V5MotorBrakeMode);
-        fn vexDeviceMotorBrakeModeGet(device: u32) -> u32, in .0;
-        fn vexDeviceMotorPositionSet(device: u32, position: c_double);
-        fn vexDeviceMotorPositionGet(device: u32) -> c_double;
-        // fn vexDeviceMotorPositionRawGet(device: u32, timestamp: *mut u32) -> i32;
-        fn vexDeviceMotorPositionReset(device: u32);
-        fn vexDeviceMotorTargetGet(device: u32) -> c_double;
-        fn vexDeviceMotorServoTargetSet(device: u32, position: c_double);
-        fn vexDeviceMotorAbsoluteTargetSet(device: u32, position: c_double, veloctiy: i32);
-        fn vexDeviceMotorRelativeTargetSet(device: u32, position: c_double, velocity: i32);
-        fn vexDeviceMotorFaultsGet(device: u32) -> u32;
-        fn vexDeviceMotorFlagsGet(device: u32) -> u32;
-        fn vexDeviceMotorVoltageSet(device: u32, voltage: i32);
-        fn vexDeviceMotorVoltageGet(device: u32) -> i32;
-        fn vexDeviceMotorGearingSet(device: u32, gearset: u32 as V5MotorGearset);
-        fn vexDeviceMotorGearingGet(device: u32) -> u32, in .0;
-        fn vexDeviceMotorVoltageLimitSet(device: u32, limit: i32);
-        fn vexDeviceMotorVoltageLimitGet(device: u32) -> i32;
-        fn vexDeviceMotorVelocityUpdate(device: u32, velocity: i32);
-        // fn vexDeviceMotorPositionPidSet(device: u32, pid: *mut V5_DeviceMotorPid);
-        // fn vexDeviceMotorVelocityPidSet(device: u32, pid: *mut V5_DeviceMotorPid);
-        fn vexDeviceMotorExternalProfileSet(device: u32, position: c_double, velocity: i32);
-
-        // Serial
-        fn vexSerialWriteChar(channel: u32, c: u32) -> i32;
-        fn vexSerialReadChar(channel: u32) -> i32;
-        fn vexSerialPeekChar(channel: u32) -> i32;
-        fn vexSerialWriteFree(channel: u32) -> i32;
-
-        // System
-        fn vexSystemTimeGet() -> u32;
-        fn vexSystemExitRequest();
-        fn vexSystemHighResTimeGet() -> u64;
-        fn vexSystemPowerupTimeGet() -> u64;
-        fn vexSystemLinkAddrGet() -> u32;
-        fn vexSystemVersion() -> u32;
-        fn vexStdlibVersion() -> u32;
-
-        // Misc
-        fn vexTasksRun();
-        fn vexCompetitionStatus() -> u32;
     });
 
     printf_style!(instance, store, mod "vex" {
@@ -203,24 +184,286 @@ pub fn link(store: &mut Store<Data>, instance: &mut Instance<Data>) -> anyhow::R
         fn vexDisplayBigCenteredString(nLineNumber: i32, @printf@);
     });
 
-    instance.link_closure(
-        &mut *store,
-        "vex",
-        "vexDeviceGetStatus",
-        |mut ctx, devices| {
-            let teavm = ctx.data().teavm.clone().unwrap();
-            let array_ptr = (teavm.byte_array_data)(ctx.as_context_mut(), devices).unwrap();
-            let memory = ctx.memory_mut();
-            let devices = &mut memory
-                [array_ptr as usize..(array_ptr as usize + vex_sdk::V5_MAX_DEVICE_PORTS)];
+    link!(instance, store, mod "vex" {
+    // AbsEnc
+    fn vexDeviceAbsEncReset(device: u32);
+    fn vexDeviceAbsEncPositionSet(device: u32, position: i32);
+    fn vexDeviceAbsEncPositionGet(device: u32) -> i32;
+    fn vexDeviceAbsEncVelocityGet(device: u32) -> i32;
+    fn vexDeviceAbsEncAngleGet(device: u32) -> i32;
+    fn vexDeviceAbsEncReverseFlagSet(device: u32, value: bool);
+    fn vexDeviceAbsEncReverseFlagGet(device: u32) -> bool;
+    fn vexDeviceAbsEncStatusGet(device: u32) -> u32;
+    fn vexDeviceAbsEncDataRateSet(device: u32, rate: u32);
+    // Adi
+    fn vexDeviceAdiPortConfigSet(device: u32, port: u32, config: u32 as V5_AdiPortConfiguration);
+    fn vexDeviceAdiPortConfigGet(device: u32, port: u32) -> u32, in .0;
+    fn vexDeviceAdiValueSet(device: u32, port: u32, value: i32);
+    fn vexDeviceAdiValueGet(device: u32, port: u32) -> i32;
+    fn vexDeviceAdiAddrLedSet(device: u32, port: u32, pData: u32, nOffset: u32, nLength: u32, options: u32);
+    fn vexDeviceBumperGet(device: u32) -> u32, in .0;
+    fn vexDeviceGyroReset(device: u32);
+    fn vexDeviceGyroHeadingGet(device: u32) -> c_double;
+    fn vexDeviceGyroDegreesGet(device: u32) -> c_double;
+    fn vexDeviceSonarValueGet(device: u32) -> i32;
+    // AiVision
+    fn vexDeviceAiVisionClassNameGet(device: u32, id: i32, pName: u32) -> i32;
+    fn vexDeviceAiVisionCodeGet(device: u32, id: u32, pCode: u32) -> bool;
+    fn vexDeviceAiVisionCodeSet(device: u32, pCode: u32);
+    fn vexDeviceAiVisionColorGet(device: u32, id: u32, pColor: u32) -> bool;
+    fn vexDeviceAiVisionColorSet(device: u32, pColor: u32);
+    fn vexDeviceAiVisionModeGet(device: u32) -> u32;
+    fn vexDeviceAiVisionModeSet(device: u32, mode: u32);
+    fn vexDeviceAiVisionObjectCountGet(device: u32) -> i32;
+    fn vexDeviceAiVisionObjectGet(device: u32, indexObj: u32, pObject: u32) -> i32;
+    fn vexDeviceAiVisionSensorSet(device: u32, brightness: c_double, contrast: c_double);
+    fn vexDeviceAiVisionStatusGet(device: u32) -> u32;
+    fn vexDeviceAiVisionTemperatureGet(device: u32) -> c_double;
+    // Arm
+    fn vexDeviceArmMoveTipCommandLinearAdv(device: u32, position: u32, j6_rotation: c_double, j6_velocity: u32, relative: bool);
+    fn vexDeviceArmMoveTipCommandJointAdv(device: u32, position: u32, j6_rotation: c_double, j6_velocity: u32, relative: bool);
+    fn vexDeviceArmTipPositionGetAdv(device: u32, position: u32);
+    fn vexDeviceArmPoseSet(device: u32, pose: u32, velocity: u32);
+    fn vexDeviceArmMoveTipCommandLinear(device: u32, x: i32, y: i32, z: i32, pose: u32, velocity: u32, rotation: c_double, rot_velocity: u32, relative: bool);
+    fn vexDeviceArmMoveTipCommandJoint(device: u32, x: i32, y: i32, z: i32, pose: u32, velocity: u32, rotation: c_double, rot_velocity: u32, relative: bool);
+    fn vexDeviceArmMoveJointsCommand(device: u32, positions: u32, velocities: u32, j6_rotation: c_double, j6_velocity: u32, j7_volts: c_double, j7_timeout: u32, j7_i_limit: u32, relative: bool);
+    fn vexDeviceArmSpinJoints(device: u32, velocities: u32);
+    fn vexDeviceArmSetJointPositions(device: u32, new_positions: u32);
+    fn vexDeviceArmPickUpCommand(device: u32);
+    fn vexDeviceArmDropCommand(device: u32);
+    fn vexDeviceArmMoveVoltsCommand(device: u32, voltages: u32);
+    fn vexDeviceArmFullStop(device: u32, brakeMode: u32);
+    fn vexDeviceArmEnableProfiler(device: u32, enable: u32);
+    fn vexDeviceArmProfilerVelocitySet(device: u32, linear_velocity: u32, joint_velocity: u32);
+    fn vexDeviceArmSaveZeroValues(device: u32);
+    fn vexDeviceArmForceZeroCommand(device: u32);
+    fn vexDeviceArmClearZeroValues(device: u32);
+    fn vexDeviceArmBootload(device: u32);
+    fn vexDeviceArmTipPositionGet(device: u32, x: u32, y: u32, z: u32);
+    fn vexDeviceArmJointInfoGet(device: u32, positions: u32, velocities: u32, currents: u32);
+    fn vexDeviceArmJ6PositionGet(device: u32) -> c_double;
+    fn vexDeviceArmBatteryGet(device: u32) -> i32;
+    fn vexDeviceArmServoFlagsGet(device: u32, servoID: u32) -> i32;
+    fn vexDeviceArmStatusGet(device: u32) -> u32;
+    fn vexDeviceArmDebugGet(device: u32, id: i32) -> u32;
+    fn vexDeviceArmJointErrorsGet(device: u32, errors: u32);
+    fn vexDeviceArmJ6PositionSet(device: u32, position: u32);
+    fn vexDeviceArmStopJointsCommand(device: u32, brakeModes: u32);
+    fn vexDeviceArmReboot(device: u32);
+    fn vexDeviceArmTipOffsetSet(device: u32, x: i32, y: i32, z: i32);
+    // Battery
+    fn vexBatteryVoltageGet() -> i32;
+    fn vexBatteryCurrentGet() -> i32;
+    fn vexBatteryTemperatureGet() -> c_double;
+    fn vexBatteryCapacityGet() -> c_double;
+    // Competition
+    fn vexCompetitionStatus() -> u32;
+    fn vexCompetitionControl(data: u32);
+    // Controller
+    fn vexControllerGet(id: u32 as V5_ControllerId, index: u32 as V5_ControllerIndex) -> i32;
+    fn vexControllerConnectionStatusGet(id: u32 as V5_ControllerId) -> u32, in .0;
+    fn vexControllerTextSet(id: u32, line: u32, col: u32, buf: u32) -> u32;
+    // Device
+    fn vexDevicesGetNumber() -> u32;
+    fn vexDevicesGetNumberByType(device_type: u32 as V5_DeviceType) -> u32;
+    fn vexDevicesGet() -> u32;
+    fn vexDeviceGetByIndex(index: u32) -> u32;
+    fn vexDeviceGetStatus(devices: u32) -> i32;
+    fn vexDeviceGetTimestamp(device: u32) -> u32;
+    fn vexDeviceGenericValueGet(device: u32) -> c_double;
+    fn vexDeviceButtonStateGet() -> i32;
+    // Distance
+    fn vexDeviceDistanceDistanceGet(device: u32) -> u32;
+    fn vexDeviceDistanceConfidenceGet(device: u32) -> u32;
+    fn vexDeviceDistanceStatusGet(device: u32) -> u32;
+    fn vexDeviceDistanceObjectSizeGet(device: u32) -> i32;
+    fn vexDeviceDistanceObjectVelocityGet(device: u32) -> c_double;
+    // File
+    fn vexFileMountSD() -> u32, in .0;
+    fn vexFileDirectoryGet(path: u32, buffer: u32, len: u32) -> u32, in .0;
+    fn vexFileOpen(filename: u32, mode: u32) -> u32;
+    fn vexFileOpenWrite(filename: u32) -> u32;
+    fn vexFileOpenCreate(filename: u32) -> u32;
+    fn vexFileClose(fdp: u32);
+    fn vexFileWrite(buf: u32, size: u32, nItems: u32, fdp: u32) -> i32;
+    fn vexFileSize(fdp: u32) -> i32;
+    fn vexFileSeek(fdp: u32, offset: u32, whence: i32) -> u32, in .0;
+    fn vexFileRead(buf: u32, size: u32, nItems: u32, fdp: u32) -> i32;
+    fn vexFileDriveStatus(drive: u32) -> bool;
+    fn vexFileTell(fdp: u32) -> i32;
+    fn vexFileSync(fdp: u32);
+    fn vexFileStatus(filename: u32) -> u32;
+    // GenericRadio
+    fn vexDeviceGenericRadioWriteFree(device: u32) -> i32;
+    fn vexDeviceGenericRadioTransmit(device: u32, data: u32, size: u32) -> i32;
+    fn vexDeviceGenericRadioReceiveAvail(device: u32) -> i32;
+    fn vexDeviceGenericRadioReceive(device: u32, data: u32, size: u32) -> i32;
+    fn vexDeviceGenericRadioLinkStatus(device: u32) -> bool;
+    // GenericSerial
+    fn vexDeviceGenericSerialEnable(device: u32, options: i32);
+    fn vexDeviceGenericSerialBaudrate(device: u32, baudrate: i32);
+    fn vexDeviceGenericSerialWriteChar(device: u32, c: u32) -> i32;
+    fn vexDeviceGenericSerialWriteFree(device: u32) -> i32;
+    fn vexDeviceGenericSerialTransmit(device: u32, buffer: u32, length: i32) -> i32;
+    fn vexDeviceGenericSerialReadChar(device: u32) -> i32;
+    fn vexDeviceGenericSerialPeekChar(device: u32) -> i32;
+    fn vexDeviceGenericSerialReceiveAvail(device: u32) -> i32;
+    fn vexDeviceGenericSerialReceive(device: u32, buffer: u32, length: i32) -> i32;
+    fn vexDeviceGenericSerialFlush(device: u32);
+    // Gps
+    fn vexDeviceGpsReset(device: u32);
+    fn vexDeviceGpsHeadingGet(device: u32) -> c_double;
+    fn vexDeviceGpsDegreesGet(device: u32) -> c_double;
+    fn vexDeviceGpsQuaternionGet(device: u32, data: u32);
+    fn vexDeviceGpsAttitudeGet(device: u32, data: u32, bRaw: bool);
+    fn vexDeviceGpsRawGyroGet(device: u32, data: u32);
+    fn vexDeviceGpsRawAccelGet(device: u32, data: u32);
+    fn vexDeviceGpsStatusGet(device: u32) -> u32;
+    fn vexDeviceGpsModeSet(device: u32, mode: u32);
+    fn vexDeviceGpsModeGet(device: u32) -> u32;
+    fn vexDeviceGpsDataRateSet(device: u32, rate: u32);
+    fn vexDeviceGpsOriginSet(device: u32, ox: c_double, oy: c_double);
+    fn vexDeviceGpsOriginGet(device: u32, ox: u32, oy: u32);
+    fn vexDeviceGpsRotationSet(device: u32, value: c_double);
+    fn vexDeviceGpsRotationGet(device: u32) -> c_double;
+    fn vexDeviceGpsInitialPositionSet(device: u32, initial_x: c_double, initial_y: c_double, initial_rotation: c_double);
+    fn vexDeviceGpsErrorGet(device: u32) -> c_double;
+    // Imu
+    fn vexDeviceImuReset(device: u32);
+    fn vexDeviceImuHeadingGet(device: u32) -> c_double;
+    fn vexDeviceImuDegreesGet(device: u32) -> c_double;
+    fn vexDeviceImuQuaternionGet(device: u32, data: u32);
+    fn vexDeviceImuAttitudeGet(device: u32, data: u32);
+    fn vexDeviceImuRawGyroGet(device: u32, data: u32);
+    fn vexDeviceImuRawAccelGet(device: u32, data: u32);
+    fn vexDeviceImuStatusGet(device: u32) -> u32;
+    fn vexDeviceImuModeSet(device: u32, mode: u32);
+    fn vexDeviceImuModeGet(device: u32) -> u32;
+    fn vexDeviceImuDataRateSet(device: u32, rate: u32);
+    // Led
+    fn vexDeviceLedSet(device: u32, value: u32 as V5_DeviceLedColor);
+    fn vexDeviceLedRgbSet(device: u32, color: u32);
+    fn vexDeviceLedGet(device: u32) -> u32, in .0;
+    fn vexDeviceLedRgbGet(device: u32) -> u32;
+    // LightTower
+    fn vexDeviceLightTowerBlinkSet(device: u32, select: u32, mask: u32, onTime: i32, offTime: i32);
+    fn vexDeviceLightTowerColorSet(device: u32, color_id: u32, value: u32);
+    fn vexDeviceLightTowerRgbGet(device: u32) -> u32;
+    fn vexDeviceLightTowerRgbSet(device: u32, rgb_value: u32, xyw_value: u32);
+    fn vexDeviceLightTowerStatusGet(device: u32) -> u32;
+    fn vexDeviceLightTowerDebugGet(device: u32, id: i32) -> u32;
+    fn vexDeviceLightTowerXywGet(device: u32) -> u32;
+    // Magnet
+    fn vexDeviceMagnetPowerSet(device: u32, value: i32, time: i32);
+    fn vexDeviceMagnetPowerGet(device: u32) -> i32;
+    fn vexDeviceMagnetPickup(device: u32, duration: u32 as V5_DeviceMagnetDuration);
+    fn vexDeviceMagnetDrop(device: u32, duration: u32 as V5_DeviceMagnetDuration);
+    fn vexDeviceMagnetTemperatureGet(device: u32) -> c_double;
+    fn vexDeviceMagnetCurrentGet(device: u32) -> c_double;
+    fn vexDeviceMagnetStatusGet(device: u32) -> u32;
+    // Motor
+    fn vexDeviceMotorVelocitySet(device: u32, velocity: i32);
+    fn vexDeviceMotorVelocityGet(device: u32) -> i32;
+    fn vexDeviceMotorActualVelocityGet(device: u32) -> c_double;
+    fn vexDeviceMotorDirectionGet(device: u32) -> i32;
+    fn vexDeviceMotorModeSet(device: u32, mode: u32 as V5MotorControlMode);
+    fn vexDeviceMotorModeGet(device: u32) -> u32, in .0;
+    fn vexDeviceMotorPwmSet(device: u32, pwm: i32);
+    fn vexDeviceMotorPwmGet(device: u32) -> i32;
+    fn vexDeviceMotorCurrentLimitSet(device: u32, limit: i32);
+    fn vexDeviceMotorCurrentLimitGet(device: u32) -> i32;
+    fn vexDeviceMotorCurrentGet(device: u32) -> i32;
+    fn vexDeviceMotorPowerGet(device: u32) -> c_double;
+    fn vexDeviceMotorTorqueGet(device: u32) -> c_double;
+    fn vexDeviceMotorEfficiencyGet(device: u32) -> c_double;
+    fn vexDeviceMotorTemperatureGet(device: u32) -> c_double;
+    fn vexDeviceMotorOverTempFlagGet(device: u32) -> bool;
+    fn vexDeviceMotorCurrentLimitFlagGet(device: u32) -> bool;
+    fn vexDeviceMotorZeroVelocityFlagGet(device: u32) -> bool;
+    fn vexDeviceMotorZeroPositionFlagGet(device: u32) -> bool;
+    fn vexDeviceMotorReverseFlagSet(device: u32, reverse: bool);
+    fn vexDeviceMotorReverseFlagGet(device: u32) -> bool;
+    fn vexDeviceMotorEncoderUnitsSet(device: u32, units: u32 as V5MotorEncoderUnits);
+    fn vexDeviceMotorEncoderUnitsGet(device: u32) -> u32, in .0;
+    fn vexDeviceMotorBrakeModeSet(device: u32, mode: u32 as V5MotorBrakeMode);
+    fn vexDeviceMotorBrakeModeGet(device: u32) -> u32, in .0;
+    fn vexDeviceMotorPositionSet(device: u32, position: c_double);
+    fn vexDeviceMotorPositionGet(device: u32) -> c_double;
+    fn vexDeviceMotorPositionRawGet(device: u32, timestamp: u32) -> i32;
+    fn vexDeviceMotorPositionReset(device: u32);
+    fn vexDeviceMotorTargetGet(device: u32) -> c_double;
+    fn vexDeviceMotorServoTargetSet(device: u32, position: c_double);
+    fn vexDeviceMotorAbsoluteTargetSet(device: u32, position: c_double, veloctiy: i32);
+    fn vexDeviceMotorRelativeTargetSet(device: u32, position: c_double, velocity: i32);
+    fn vexDeviceMotorFaultsGet(device: u32) -> u32;
+    fn vexDeviceMotorFlagsGet(device: u32) -> u32;
+    fn vexDeviceMotorVoltageSet(device: u32, voltage: i32);
+    fn vexDeviceMotorVoltageGet(device: u32) -> i32;
+    fn vexDeviceMotorGearingSet(device: u32, gearset: u32 as V5MotorGearset);
+    fn vexDeviceMotorGearingGet(device: u32) -> u32, in .0;
+    fn vexDeviceMotorVoltageLimitSet(device: u32, limit: i32);
+    fn vexDeviceMotorVoltageLimitGet(device: u32) -> i32;
+    fn vexDeviceMotorVelocityUpdate(device: u32, velocity: i32);
+    fn vexDeviceMotorPositionPidSet(device: u32, pid: u32);
+    fn vexDeviceMotorVelocityPidSet(device: u32, pid: u32);
+    fn vexDeviceMotorExternalProfileSet(device: u32, position: c_double, velocity: i32);
+    // Optical
+    fn vexDeviceOpticalHueGet(device: u32) -> c_double;
+    fn vexDeviceOpticalSatGet(device: u32) -> c_double;
+    fn vexDeviceOpticalBrightnessGet(device: u32) -> c_double;
+    fn vexDeviceOpticalProximityGet(device: u32) -> i32;
+    fn vexDeviceOpticalRgbGet(device: u32, data: u32);
+    fn vexDeviceOpticalLedPwmSet(device: u32, value: i32);
+    fn vexDeviceOpticalLedPwmGet(device: u32) -> i32;
+    fn vexDeviceOpticalStatusGet(device: u32) -> u32;
+    fn vexDeviceOpticalRawGet(device: u32, data: u32);
+    fn vexDeviceOpticalModeSet(device: u32, mode: u32);
+    fn vexDeviceOpticalModeGet(device: u32) -> u32;
+    fn vexDeviceOpticalGestureGet(device: u32, pData: u32) -> u32;
+    fn vexDeviceOpticalGestureEnable(device: u32);
+    fn vexDeviceOpticalGestureDisable(device: u32);
+    fn vexDeviceOpticalProximityThreshold(device: u32, value: i32);
+    fn vexDeviceOpticalIntegrationTimeSet(device: u32, timeMs: c_double);
+    fn vexDeviceOpticalIntegrationTimeGet(device: u32) -> c_double;
+    // Pneumatic
+    fn vexDevicePneumaticActuationStatusGet(device: u32, ac1: u32, ac2: u32, ac3: u32, ac4: u32) -> u32;
+    fn vexDevicePneumaticCompressorSet(device: u32, bState: bool);
+    fn vexDevicePneumaticCtrlSet(device: u32, pCtrl: u32);
+    fn vexDevicePneumaticCylinderPwmSet(device: u32, id: u32, bState: bool, pwm: u32);
+    fn vexDevicePneumaticCylinderSet(device: u32, id: u32, bState: bool);
+    fn vexDevicePneumaticPwmGet(device: u32) -> u32;
+    fn vexDevicePneumaticPwmSet(device: u32, pwm: u32);
+    fn vexDevicePneumaticStatusGet(device: u32) -> u32;
+    // Range
+    fn vexDeviceRangeValueGet(device: u32) -> i32;
+    // Serial
+    fn vexSerialWriteChar(channel: u32, c: u32) -> i32;
+    fn vexSerialWriteBuffer(channel: u32, data: u32, data_len: u32) -> i32;
+    fn vexSerialReadChar(channel: u32) -> i32;
+    fn vexSerialPeekChar(channel: u32) -> i32;
+    fn vexSerialWriteFree(channel: u32) -> i32;
+    // Touch
+    fn vexTouchDataGet(status: u32);
+    });
 
-            let devices = unsafe {
-                // SAFETY: V5_DeviceType is a repr(transparent) struct holding a u8
-                core::mem::transmute::<*mut u8, *mut V5_DeviceType>(devices.as_mut_ptr())
-            };
-            Ok(unsafe { vex_sdk::vexDeviceGetStatus(devices) })
-        },
-    )?;
+    // instance.link_closure(
+    //     &mut *store,
+    //     "vex",
+    //     "vexDeviceGetStatus",
+    //     |mut ctx, devices| {
+    //         let teavm = ctx.data().teavm.clone().unwrap();
+    //         let array_ptr = (teavm.byte_array_data)(ctx.as_context_mut(), devices).unwrap();
+    //         let memory = ctx.memory_mut();
+    //         let devices = &mut memory
+    //             [array_ptr as usize..(array_ptr as usize + vex_sdk::V5_MAX_DEVICE_PORTS)];
+
+    //         let devices = unsafe {
+    //             // SAFETY: V5_DeviceType is a repr(transparent) struct holding a u8
+    // core::mem::transmute::<*mut u8, *mut V5_DeviceType>(devices.as_mut_ptr())
+    //         };
+    //         Ok(unsafe { vex_sdk::vexDeviceGetStatus(devices) })
+    //     },
+    // )?;
 
     instance.link_closure(
         &mut *store,

--- a/packages/runtime/src/teavm.rs
+++ b/packages/runtime/src/teavm.rs
@@ -4,7 +4,7 @@ use alloc::{ffi::CString, rc::Rc, string::String};
 use core::str;
 
 use anyhow::{Context, Result};
-use vexide::core::{print, println, time::Instant};
+use vexide::{io::print, io::println, time::Instant};
 use wasm3::{
     store::{AsContextMut, StoreContextMut},
     Function, Instance, Store,
@@ -61,6 +61,11 @@ pub fn link_teavm(store: &mut Store<Data>, instance: &mut Instance<Data>) -> Res
     instance.link_closure(store, "teavm", "currentTimeMillis", move |_ctx, ()| {
         let secs = epoch.elapsed().as_secs_f64();
         Ok(secs * 1000.0)
+    })?;
+
+    instance.link_closure(store, "teavm", "nanoTime", move |_ctx, ()| {
+        let nanos = epoch.elapsed().as_nanos() as f64 / 1000000.0;
+        Ok(nanos)
     })?;
 
     instance.link_closure(store, "teavm", "logString", move |mut ctx, string: i32| {

--- a/packages/runtime/src/teavm.rs
+++ b/packages/runtime/src/teavm.rs
@@ -4,7 +4,11 @@ use alloc::{ffi::CString, rc::Rc, string::String};
 use core::str;
 
 use anyhow::{Context, Result};
-use vexide::{io::print, io::println, time::Instant};
+use vexide::{
+    float::Float,
+    io::{print, println},
+    time::Instant,
+};
 use wasm3::{
     store::{AsContextMut, StoreContextMut},
     Function, Instance, Store,
@@ -67,6 +71,33 @@ pub fn link_teavm(store: &mut Store<Data>, instance: &mut Instance<Data>) -> Res
         let nanos = epoch.elapsed().as_nanos() as f64 / 1000000.0;
         Ok(nanos)
     })?;
+
+    instance.link_closure(store, "teavmMath", "sin", move |_ctx, a: f64| Ok(a.sin()))?;
+    instance.link_closure(store, "teavmMath", "cos", move |_ctx, a: f64| Ok(a.cos()))?;
+    instance.link_closure(store, "teavmMath", "tan", move |_ctx, a: f64| Ok(a.tan()))?;
+    instance.link_closure(store, "teavmMath", "asin", move |_ctx, a: f64| Ok(a.asin()))?;
+    instance.link_closure(store, "teavmMath", "acos", move |_ctx, a: f64| Ok(a.acos()))?;
+    instance.link_closure(store, "teavmMath", "atan", move |_ctx, a: f64| Ok(a.atan()))?;
+    instance.link_closure(store, "teavmMath", "exp", move |_ctx, a: f64| Ok(a.exp()))?;
+    instance.link_closure(store, "teavmMath", "log", move |_ctx, a: f64| Ok(a.ln()))?;
+    instance.link_closure(store, "teavmMath", "sqrt", move |_ctx, a: f64| Ok(a.sqrt()))?;
+    instance.link_closure(store, "teavmMath", "ceil", move |_ctx, a: f64| Ok(a.ceil()))?;
+    instance.link_closure(store, "teavmMath", "floor", move |_ctx, a: f64| {
+        Ok(a.floor())
+    })?;
+    instance.link_closure(
+        store,
+        "teavmMath",
+        "pow",
+        move |_ctx, (x, y): (f64, f64)| Ok(x.powf(y)),
+    )?;
+    instance.link_closure(
+        store,
+        "teavmMath",
+        "atan2",
+        move |_ctx, (y, x): (f64, f64)| Ok(y.atan2(x)),
+    )?;
+
 
     instance.link_closure(store, "teavm", "logString", move |mut ctx, string: i32| {
         let string = get_string(&mut ctx, string);

--- a/packages/startup/src/lib.rs
+++ b/packages/startup/src/lib.rs
@@ -146,6 +146,6 @@ pub unsafe fn startup() {
         );
 
         // Initialize the heap allocator
-        vexide::core::allocator::claim(addr_of_mut!(__heap_start), addr_of_mut!(__heap_end));
+        vexide::allocator::claim(addr_of_mut!(__heap_start), addr_of_mut!(__heap_end));
     }
 }

--- a/packages/startup/src/lib.rs
+++ b/packages/startup/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::needless_doctest_main)]
 
 use bitflags::bitflags;
+use core::ptr::addr_of_mut;
 
 /// Identifies the type of binary to VEXos.
 #[repr(u32)]
@@ -121,6 +122,11 @@ where
     }
 }
 
+unsafe extern "C" {
+    static mut __heap_start: u8;
+    static mut __heap_end: u8;
+}
+
 /// Startup Routine
 ///
 /// - Sets up the heap allocator if necessary.
@@ -140,6 +146,6 @@ pub unsafe fn startup() {
         );
 
         // Initialize the heap allocator
-        vexide::core::allocator::init_heap();
+        vexide::core::allocator::claim(addr_of_mut!(__heap_start), addr_of_mut!(__heap_end));
     }
 }

--- a/packages/wasm3/src/module.rs
+++ b/packages/wasm3/src/module.rs
@@ -130,7 +130,7 @@ impl<T> Instance<T> {
     }
 
     /// Links the given closure to the corresponding module and function name.
-    /// This boxes the closure and therefor requires a heap allocation.
+    /// This boxes the closure and therefore requires a heap allocation.
     ///
     /// # Errors
     ///

--- a/packages/wasm3/src/ty.rs
+++ b/packages/wasm3/src/ty.rs
@@ -14,10 +14,10 @@ pub trait WasmType: Sized + Sealed {
     unsafe fn push_on_stack(self, stack: *mut u64);
 }
 
-/// Tait implemented by types that can be passed to wasm.
+/// Trait implemented by types that can be passed to wasm.
 pub trait WasmArg: WasmType {}
 
-/// Helper tait implemented by tuples to emulate "variadic generics".
+/// Helper trait implemented by tuples to emulate "variadic generics".
 #[allow(private_bounds)]
 pub trait WasmArgs: Sealed {
     unsafe fn push_on_stack(self, stack: *mut u64);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-08-20"
+channel = "nightly-2025-04-03"
 components = ["rust-src"]


### PR DESCRIPTION
- updated vexide dependency
- fixed some small doc typos

The additional SDK methods were auto-generated by a slightly scuffed python script. I added the `getByteArrayPointer` method to allow the SDK to get access to the WASM runtime's memory to pass struct data. Commented out are some other methods to do the opposite (give the WASM runtime access to program memory), but they do the same thing and I think the former is less error-prone.